### PR TITLE
Update get call to include optional default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ And then just you have to manipulate the settings.
 
 
 ```php
-
-// Get the value of the API_GOOGLE key, null if it doesn't exist
-
 use Inani\LaravelNovaConfiguration\Helpers\Configuration;
 
+// Get the value of the API_GOOGLE key, null if it doesn't exist
 $value = Configuration::get('API_GOOGLE');
 
+// Get the value of the FOO key, 'BAR' if it doesn't exist
+$value = Configuration::get('FOO', 'BAR);
 ```
 
 #### Updating the sidebar bar label

--- a/src/Helpers/Configuration.php
+++ b/src/Helpers/Configuration.php
@@ -15,12 +15,12 @@ class Configuration extends Model
      * @param $key
      * @return mixed
      */
-    public static function get($key)
+    public static function get($key, $default = null)
     {
         $line =  self::getElementByKey($key);
 
         if(is_null($line)){
-            return null;
+            return $default;
         }
 
         return $line->value;


### PR DESCRIPTION
This does **not** break current implementations of this package. This is nice so we don't always have to include a 
```
$value = Configuration::get('foo');
if ($value === null) {
    $value = 'default';
}
// Do something with $value
```
And can instead use 
```
$value = Configuration::get('foo', 'default');
```